### PR TITLE
Deluxe Edition

### DIFF
--- a/app/src/androidTest/java/com/klamerek/fantasyrealms/game/GameTest.kt
+++ b/app/src/androidTest/java/com/klamerek/fantasyrealms/game/GameTest.kt
@@ -11,7 +11,7 @@ class GameTest {
     @DisplayName("Same card cannot be added twice")
     @Test
     fun same_card_cannot_be_added_twice() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(necromancer)
         game.add(necromancer)
 
@@ -21,7 +21,7 @@ class GameTest {
     @DisplayName("Remove card")
     @Test
     fun remove_card() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(necromancer)
         game.add(doppelganger)
         game.add(candle)
@@ -34,7 +34,7 @@ class GameTest {
     @DisplayName("Update card list")
     @Test
     fun update_card_list() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(necromancer)
         game.add(candle)
 
@@ -56,7 +56,7 @@ class GameTest {
         Preferences.saveBuildingsOutsidersUndeadInPreferences(
             InstrumentationRegistry.getInstrumentation().targetContext, true)
 
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(necromancer)
         game.add(necromancerV2)
         game.add(genie)

--- a/app/src/androidTest/java/com/klamerek/fantasyrealms/game/ScoringTest.kt
+++ b/app/src/androidTest/java/com/klamerek/fantasyrealms/game/ScoringTest.kt
@@ -862,4 +862,82 @@ class ScoringTest {
         Assertions.assertEquals(10, game.score())
     }
 
+    @DisplayName("Deluxe Edition Wildfire")
+    @Test
+    fun deluxe_edition_wildfire() {
+        val baseGame = Game(deluxeEdition = false)
+        baseGame.add(wildfire)
+        baseGame.add(leprechaun)
+        baseGame.calculate()
+        Assertions.assertEquals(40, baseGame.score(), "Wildfire should blank Leprechaun (OUTSIDER) in the base game")
+
+        val deluxeEdition = Game(deluxeEdition = true)
+        deluxeEdition.add(wildfireDeluxeEdition)
+        deluxeEdition.add(leprechaun)
+        deluxeEdition.calculate()
+        Assertions.assertEquals(40 + 20, deluxeEdition.score(), "Wildfire should not blank Leprechaun (OUTSIDER) in the Deluxe Edition")
+    }
+
+    @DisplayName("Phoenix Deluxe Edition blanked with Flood")
+    @Test
+    fun phoenix_deluxe_edition_blanked_with_flood() {
+        val game = Game(deluxeEdition = true)
+        game.add(phoenixDeluxeEdition)
+        game.add(island)
+        game.calculate()
+        Assertions.assertEquals(14, game.score())
+    }
+
+    @DisplayName("Phoenix Deluxe Edition penalty cleared")
+    @Test
+    fun phoenix_deluxe_edition_penalty_cleared() {
+        val game = Game(deluxeEdition = true)
+        game.add(phoenixDeluxeEdition)
+        game.add(island)
+        game.applySelection(island, phoenixDeluxeEdition)
+        game.calculate()
+        Assertions.assertEquals(14 + 14, game.score())
+    }
+
+    @DisplayName("Phoenix Deluxe Edition may not be blanked by another card")
+    @Test
+    fun phoenix_deluxe_edition_may_not_be_blanked_by_another_card() {
+        val game = Game(deluxeEdition = true)
+        game.add(phoenixDeluxeEdition)
+        game.add(demon)
+        game.calculate()
+        Assertions.assertEquals(14 + 45, game.score())
+    }
+
+    @DisplayName("Phoenix Deluxe Edition may not blank any other card")
+    @Test
+    fun phoenix_deluxe_edition_may_not_blank_any_other_card() {
+        val game = Game(deluxeEdition = true)
+        game.add(phoenixDeluxeEdition)
+        game.add(warDirigible)
+        game.add(celestialKnights)
+        game.calculate()
+        Assertions.assertEquals(14 + 35 + 12, game.score())
+    }
+
+    @DisplayName("Phoenix Deluxe Edition also counts as flame and weather")
+    @Test
+    fun phoenix_deluxe_edition_counts_as_flame_and_weather() {
+        val game = Game(deluxeEdition = true)
+        game.add(phoenixDeluxeEdition)
+        game.add(enchantress)
+        game.calculate()
+        Assertions.assertEquals(14 + (5 + 5), game.score())
+    }
+
+    @DisplayName("Phoenix Deluxe Edition does not count as flame or weather in discard area")
+    @Test
+    fun phoenix_deluxe_edition_does_not_count_as_flame_or_weather_in_discard() {
+        DiscardArea.instance.game().add(phoenixDeluxeEdition)
+        val game = Game(deluxeEdition = true)
+        game.add(darkQueen)
+        game.add(ghoul)
+        game.calculate()
+        Assertions.assertEquals((10 + 0) + (8 + 4), game.score())
+    }
 }

--- a/app/src/androidTest/java/com/klamerek/fantasyrealms/game/ScoringTest.kt
+++ b/app/src/androidTest/java/com/klamerek/fantasyrealms/game/ScoringTest.kt
@@ -16,7 +16,7 @@ class ScoringTest {
     @DisplayName("worst hand")
     @Test
     fun worst_hand() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(necromancer)
         game.add(warlockLord)
         game.add(king)
@@ -36,7 +36,7 @@ class ScoringTest {
     @DisplayName("best hand")
     @Test
     fun best_hand() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(bellTower)
         game.add(candle)
         game.add(necromancer)
@@ -55,7 +55,7 @@ class ScoringTest {
     @DisplayName("gem of order is effective (100 points)")
     @Test
     fun gem_of_order_is_effective() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(gemOfOrder)
         game.add(airElemental)
         game.add(necromancer)
@@ -72,7 +72,7 @@ class ScoringTest {
     @DisplayName("Unicorn and princess")
     @Test
     fun unicorn_with_princess() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(unicorn)
         game.add(princess)
         game.add(queen)
@@ -84,7 +84,7 @@ class ScoringTest {
     @DisplayName("WarlockLord rule")
     @Test
     fun warlockLord_rule() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(warlockLord)
         game.add(beastmaster)
         game.add(enchantress)
@@ -96,7 +96,7 @@ class ScoringTest {
     @DisplayName("mirage combo with shapeshifter")
     @Test
     fun mirage_combo_with_shapeshifter() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(shieldOfKeth)
         game.add(basilisk)
         game.add(protectionRune)
@@ -115,7 +115,7 @@ class ScoringTest {
     @DisplayName("full game sample 1")
     @Test
     fun full_game_sample_1() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(collector)
         game.add(unicorn)
         game.add(bellTower)
@@ -131,7 +131,7 @@ class ScoringTest {
     @DisplayName("full game sample 2")
     @Test
     fun full_game_sample_2() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(forest)
         game.add(elvenArchers)
         game.add(enchantress)
@@ -146,7 +146,7 @@ class ScoringTest {
     @DisplayName("full game sample 3")
     @Test
     fun full_game_sample_3() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(forge)
         game.add(blizzard)
         game.add(unicorn)
@@ -161,7 +161,7 @@ class ScoringTest {
     @DisplayName("full game sample 4")
     @Test
     fun full_game_sample_4() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(dragon)
         game.add(fireElemental)
         game.add(blizzard)
@@ -176,7 +176,7 @@ class ScoringTest {
     @DisplayName("full game sample 5")
     @Test
     fun full_game_sample_5() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(warlockLord)
         game.add(warhorse)
         game.add(fountainOfLife)
@@ -191,7 +191,7 @@ class ScoringTest {
     @DisplayName("full game sample 6")
     @Test
     fun full_game_sample_6() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(candle)
         game.add(protectionRune)
         game.add(elvenLongbow)
@@ -206,7 +206,7 @@ class ScoringTest {
     @DisplayName("full game sample 7")
     @Test
     fun full_game_sample_7() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(mountain)
         game.add(cavern)
         game.add(wildfire)
@@ -221,7 +221,7 @@ class ScoringTest {
     @DisplayName("full game sample 8")
     @Test
     fun full_game_sample_8() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(dragon)
         game.add(unicorn)
         game.add(basilisk)
@@ -236,7 +236,7 @@ class ScoringTest {
     @DisplayName("full game sample 9")
     @Test
     fun full_game_sample_9() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(enchantress)
         game.add(cavern)
         game.add(bellTower)
@@ -251,7 +251,7 @@ class ScoringTest {
     @DisplayName("full game sample 10")
     @Test
     fun full_game_sample_10() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(mountain)
         game.add(greatFlood)
         game.add(rainstorm)
@@ -266,7 +266,7 @@ class ScoringTest {
     @DisplayName("fountain of life take only one card (the best one)")
     @Test
     fun fountain_of_life_take_only_one_card() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(fountainOfLife)
         game.add(swamp)
         game.add(greatFlood)
@@ -279,7 +279,7 @@ class ScoringTest {
     @DisplayName("Dwarvish infantry applies on OTHER armies")
     @Test
     fun dwarvish_infantry_applies_on_OTHER_armies() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(dwarvishInfantry)
         game.add(worldTree)
         game.add(unicorn)
@@ -294,7 +294,7 @@ class ScoringTest {
     @DisplayName("Jester with all cards as odd")
     @Test
     fun jester_with_all_cards_as_odd() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(forge)
         game.add(unicorn)
         game.add(jester)
@@ -306,7 +306,7 @@ class ScoringTest {
     @DisplayName("Jester with one card not odd")
     @Test
     fun jester_with_one_card_not_odd() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(forge)
         game.add(unicorn)
         game.add(jester)
@@ -319,7 +319,7 @@ class ScoringTest {
     @DisplayName("Elven archers with weather")
     @Test
     fun elven_archers_with_weather() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(elvenArchers)
         game.add(rainstorm)
         game.calculate()
@@ -329,11 +329,11 @@ class ScoringTest {
     @DisplayName("Genie with 4 players")
     @Test
     fun genie_with_4_players() {
-        Player.all.add(Player("1", Game()))
-        Player.all.add(Player("2", Game()))
-        Player.all.add(Player("3", Game()))
-        Player.all.add(Player("4", Game()))
-        val game = Game()
+        Player.all.add(Player("1", Game(deluxeEdition = false)))
+        Player.all.add(Player("2", Game(deluxeEdition = false)))
+        Player.all.add(Player("3", Game(deluxeEdition = false)))
+        Player.all.add(Player("4", Game(deluxeEdition = false)))
+        val game = Game(deluxeEdition = false)
         game.add(genie)
         game.calculate()
         Assertions.assertEquals(-20, game.score())
@@ -342,7 +342,7 @@ class ScoringTest {
     @DisplayName("Judge with and without penalty")
     @Test
     fun judge_with_and_without_penalty() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(judge)
         game.add(celestialKnights)
         game.add(lightCavalry)
@@ -357,7 +357,7 @@ class ScoringTest {
     @DisplayName("Angel is unblankable")
     @Test
     fun angel_is_unblankable() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(angel)
         game.add(wildfire)
         game.calculate()
@@ -367,7 +367,7 @@ class ScoringTest {
     @DisplayName("Angel selection is unblankable")
     @Test
     fun angel_selection() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(angel)
         game.add(wildfire)
         game.add(celestialKnights)
@@ -379,7 +379,7 @@ class ScoringTest {
     @DisplayName("Angel selection is unblankable 2")
     @Test
     fun angel_selection_2() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(angel)
         game.add(basilisk)
         game.add(queen)
@@ -391,7 +391,7 @@ class ScoringTest {
     @DisplayName("Demon with wildfire")
     @Test
     fun demon_with_wildfire() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(wildfire)
         game.add(demon)
         game.calculate()
@@ -401,7 +401,7 @@ class ScoringTest {
     @DisplayName("Demon applies after warship clearing penalties")
     @Test
     fun demon_applies_after_warship_clearing_penalties() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(warship)
         game.add(demon)
         game.add(waterElemental)
@@ -415,7 +415,7 @@ class ScoringTest {
     @DisplayName("Demon with wild cards")
     @Test
     fun demon_with_wild_cards() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(demon)
         game.add(garden)
         game.add(earthElemental)
@@ -430,7 +430,7 @@ class ScoringTest {
     @DisplayName("Indirect blanking case (Great flood -> candle -> smoke)")
     @Test
     fun indirect_blanking_case_with_greatflood_candle_smoke() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(smoke)
         game.add(candle)
         game.add(greatFlood)
@@ -441,7 +441,7 @@ class ScoringTest {
     @DisplayName("Some specific cases with Warship and Book of changes")
     @Test
     fun some_specific_cases_with_Warship_and_book_of_changes() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(demon)
         game.add(warship)
         game.add(greatFlood)
@@ -496,7 +496,7 @@ class ScoringTest {
         DiscardArea.instance.game().add(cavern)
         DiscardArea.instance.game().add(shieldOfKeth)
 
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(darkQueen)
         game.calculate()
 
@@ -511,7 +511,7 @@ class ScoringTest {
         DiscardArea.instance.game().add(darkQueen)
         DiscardArea.instance.game().add(king)
 
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(ghoul)
         game.calculate()
 
@@ -526,7 +526,7 @@ class ScoringTest {
         DiscardArea.instance.game().add(darkQueen)
         DiscardArea.instance.game().add(demon)
 
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(specter)
         game.calculate()
 
@@ -536,7 +536,7 @@ class ScoringTest {
     @DisplayName("Lich example")
     @Test
     fun lich_example() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(lich)
         game.add(necromancer)
         game.add(darkQueen)
@@ -548,7 +548,7 @@ class ScoringTest {
     @DisplayName("Lich UNBLANKABLE")
     @Test
     fun lich_unblankable() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(lich)
         game.add(wildfire)
         game.add(darkQueen)
@@ -565,7 +565,7 @@ class ScoringTest {
         DiscardArea.instance.game().add(darkQueen)
         DiscardArea.instance.game().add(demon)
 
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(deathKnight)
         game.calculate()
 
@@ -575,7 +575,7 @@ class ScoringTest {
     @DisplayName("Dungeon example")
     @Test
     fun dungeon_example() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(dungeon)
         game.add(darkQueen)
         game.add(unicorn)
@@ -588,7 +588,7 @@ class ScoringTest {
     @DisplayName("Castle example")
     @Test
     fun castle_example() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(castle)
         game.add(dungeon)
         game.add(king)
@@ -601,7 +601,7 @@ class ScoringTest {
     @DisplayName("Crypt example")
     @Test
     fun crypt_example() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(crypt)
         game.add(darkQueen)
         game.add(ghoul)
@@ -615,7 +615,7 @@ class ScoringTest {
     @DisplayName("Chapel not activated because too many cards")
     @Test
     fun chapel_not_activated_because_too_many_cards() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(chapel)
         game.add(king)
         game.add(queen)
@@ -628,7 +628,7 @@ class ScoringTest {
     @DisplayName("Chapel activated")
     @Test
     fun chapel_activated() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(chapel)
         game.add(king)
         game.add(queen)
@@ -640,7 +640,7 @@ class ScoringTest {
     @DisplayName("Garden example")
     @Test
     fun garden_activated() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(garden)
         game.add(king)
         game.add(queen)
@@ -653,7 +653,7 @@ class ScoringTest {
     @DisplayName("Garden blanked")
     @Test
     fun garden_blanked() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(garden)
         game.add(king)
         game.add(queen)
@@ -667,7 +667,7 @@ class ScoringTest {
     @DisplayName("Fountain of life v2 example")
     @Test
     fun fountain_of_life_v2_example() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(fountainOfLifeV2)
         game.add(rainstorm)
         game.add(whirlwind)
@@ -679,7 +679,7 @@ class ScoringTest {
     @DisplayName("Count OTHER cards with book of change")
     @Test
     fun count_OTHER_cards_with_book_of_change() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(whirlwind)
         game.add(airElemental)
         game.add(bookOfChanges)
@@ -692,7 +692,7 @@ class ScoringTest {
     @DisplayName("Phoenix counts also as Flame and Weather (elemental case)")
     @Test
     fun phoenix_counts_also_as_flame_and_weather_elemental_case() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(phoenix)
         game.add(airElemental)
         game.add(fireElemental)
@@ -704,7 +704,7 @@ class ScoringTest {
     @DisplayName("Phoenix counts also as Flame and Weather (collector and blank effect)")
     @Test
     fun phoenix_counts_also_as_flame_and_weather_collector_and_blank() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(phoenix)
         game.add(collector)
         game.add(rainstorm)
@@ -718,7 +718,7 @@ class ScoringTest {
     @DisplayName("Phoenix is blanked with water elemental")
     @Test
     fun phoenix_is_blanked_with_water_elemental() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(phoenix)
         game.add(waterElemental)
         game.calculate()
@@ -729,7 +729,7 @@ class ScoringTest {
     @DisplayName("Discard game effects are disabled")
     @Test
     fun discard_game_effects_are_disabled() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(deathKnight)
         game.calculate()
 
@@ -748,7 +748,7 @@ class ScoringTest {
     @DisplayName("Basilik + doppelganger blank each other")
     @Test
     fun basilik_plus_doppelganger_bank_each_other() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(basilisk)
         game.add(doppelganger)
         game.applySelection(doppelganger, basilisk)
@@ -760,7 +760,7 @@ class ScoringTest {
     @DisplayName("Clearing and blanking order (great flood, wildfire and blizzard)")
     @Test
     fun clearing_and_blanking_order() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(wildfire)
         game.add(blizzard)
         game.add(greatFlood)
@@ -812,7 +812,7 @@ class ScoringTest {
     @DisplayName("Chapel bonus is activated with one leader and one wizard")
     @Test
     fun chapel_bonus_is_activated_with_one_leader_and_one_wizard() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(chapel)
         game.add(king)
         game.add(collector)
@@ -824,7 +824,7 @@ class ScoringTest {
     @DisplayName("Doppelganger effect is not cumulative with Collector")
     @Test
     fun doppelganger_effect_is_not_cumulative_with_collector() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(collector)
         game.add(celestialKnights)
         game.add(elvenArchers)
@@ -840,7 +840,7 @@ class ScoringTest {
     @DisplayName("Ranger only remove word Army, not whole malus (bug with Swamp)")
     @Test
     fun ranger_only_remove_word_army_not_whole_malus() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(swamp)
         game.add(celestialKnights)
         game.add(fireElemental)
@@ -855,7 +855,7 @@ class ScoringTest {
     fun dark_queen_doubles_effect_with_phoenix() {
         DiscardArea.instance.game().add(phoenix)
 
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(darkQueen)
         game.calculate()
 

--- a/app/src/androidTest/java/com/klamerek/fantasyrealms/screen/HandSelectionActivityTest.kt
+++ b/app/src/androidTest/java/com/klamerek/fantasyrealms/screen/HandSelectionActivityTest.kt
@@ -2,7 +2,6 @@ package com.klamerek.fantasyrealms.screen
 
 import android.app.Instrumentation
 import android.content.Intent
-import android.os.SystemClock
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -23,7 +22,6 @@ import com.klamerek.fantasyrealms.matcher.RecycleViewMatcher
 import com.klamerek.fantasyrealms.util.Constants
 import com.klamerek.fantasyrealms.util.Preferences
 import com.klamerek.fantasyrealms.viewaction.ButtonClick
-import com.klamerek.fantasyrealms.viewaction.ImageButtonClick
 import org.greenrobot.eventbus.EventBus
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -36,7 +34,7 @@ class HandSelectionActivityTest {
     private lateinit var scenario: ActivityScenario<HandSelectionActivity>
 
     private fun initPlayer(playerName: String, actualHand: List<CardDefinition>): ActivityScenario<HandSelectionActivity> {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         actualHand.forEach { game.add(it) }
         Player.all.clear()
         Player.all.add(Player(playerName, game))
@@ -77,12 +75,12 @@ class HandSelectionActivityTest {
 
     @Test
     fun select_specific_player() {
-        val game = Game()
+        val game = Game(deluxeEdition = false)
         game.add(basilisk)
         Player.all.clear()
-        Player.all.add(Player("PLAYER 1", Game()))
+        Player.all.add(Player("PLAYER 1", Game(deluxeEdition = false)))
         Player.all.add(Player("PLAYER 2", game))
-        Player.all.add(Player("PLAYER 3", Game()))
+        Player.all.add(Player("PLAYER 3", Game(deluxeEdition = false)))
 
         val handSelectionIntent = Intent(
             InstrumentationRegistry.getInstrumentation().targetContext,

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/Card.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/Card.kt
@@ -7,15 +7,15 @@ package com.klamerek.fantasyrealms.game
  * @property definition card definition
  * @property rules      rules assigned to this card
  */
-class Card(val definition: CardDefinition, private val rules: List<Rule<out Any>>) {
+class Card(val definition: CardDefinition, private val rules: List<Rule<*>>) {
 
     private var simulatedName: String? = null
     private var simulatedValue: Int? = null
     private var simulatedSuit: Suit? = null
-    private var simulatedRules: List<Rule<out Any>>? = null
+    private var simulatedRules: List<Rule<*>>? = null
     var blanked: Boolean = false
-    private val ruleDeactivated: ArrayList<Rule<out Any>> = ArrayList()
-    private val temporaryRules: ArrayList<Rule<out Any>> = ArrayList()
+    private val ruleDeactivated: ArrayList<Rule<*>> = ArrayList()
+    private val temporaryRules: ArrayList<Rule<*>> = ArrayList()
 
     fun clear() {
         temporaryRules.clear()
@@ -31,11 +31,11 @@ class Card(val definition: CardDefinition, private val rules: List<Rule<out Any>
         simulatedRules = null
     }
 
-    fun addTemporaryRule(rule: Rule<out Any>) = temporaryRules.add(rule)
+    fun addTemporaryRule(rule: Rule<*>) = temporaryRules.add(rule)
 
-    fun deactivate(rule: Rule<out Any>) = ruleDeactivated.add(rule)
+    fun deactivate(rule: Rule<*>) = ruleDeactivated.add(rule)
 
-    fun isActivated(rule: Rule<out Any>): Boolean = !ruleDeactivated.contains(rule)
+    fun isActivated(rule: Rule<*>): Boolean = !ruleDeactivated.contains(rule)
 
     fun isOneOf(vararg suit: Suit) = suit.contains(this.suit()) ||
             definition.additionalSuits.any { suit.contains(it) }
@@ -50,7 +50,7 @@ class Card(val definition: CardDefinition, private val rules: List<Rule<out Any>
 
     fun isOdd(): Boolean = value() % 2 == 1
 
-    fun rules(): List<Rule<out Any>> = listOf(simulatedRules ?: rules, temporaryRules).flatten()
+    fun rules(): List<Rule<*>> = listOf(simulatedRules ?: rules, temporaryRules).flatten()
 
     fun name(name: String) {
         this.simulatedName = name
@@ -64,7 +64,7 @@ class Card(val definition: CardDefinition, private val rules: List<Rule<out Any>
         this.simulatedSuit = suit
     }
 
-    fun rules(rules: List<Rule<out Any>>) {
+    fun rules(rules: List<Rule<*>>) {
         this.simulatedRules = rules
     }
 

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/CardDefinition.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/CardDefinition.kt
@@ -33,7 +33,8 @@ enum class Effect(private val displayId: Int) : Tag {
 enum class CardSet(val numberOfCards: Int) {
     BASE(53),
     PROMO(2),
-    CURSED_HOARD(47)
+    CURSED_HOARD(47),
+    DELUXE_EDITION(2)
 }
 
 enum class CardPosition {
@@ -118,6 +119,3 @@ open class CardDefinition(
         return id
     }
 }
-
-
-

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/CardDefinitions.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/CardDefinitions.kt
@@ -17,13 +17,17 @@ object CardDefinitions {
      * Warning, this method gives ALL card definitions (meaning that you can see many times the same card if it has many versions)
      */
     fun getAll(): List<CardDefinition> {
-        return getBaseCards().plus(getCardsV2()).plus(getCursedHoardNewCards()).plus(getCursedItems()).plus(getPromo())
+        return getBaseCards()
+            .plus(getCardsV2()).plus(getCursedHoardNewCards()).plus(getCursedItems())
+            .plus(getPromo())
+            .plus(getDeluxeEditionChangedCards())
     }
 
     fun get(context: Context): List<CardDefinition> {
         val buildingsOutsidersUndead = Preferences.getBuildingsOutsidersUndead(context)
         val cursedItems = Preferences.getCursedItems(context)
-        return get(buildingsOutsidersUndead, cursedItems)
+        val deluxeEdition = Preferences.getDeluxeEdition(context)
+        return get(buildingsOutsidersUndead, cursedItems, deluxeEdition)
     }
 
     private fun getCardsV2(): List<CardDefinition> {
@@ -148,21 +152,40 @@ object CardDefinitions {
                 wishing_ring)
     }
 
-    fun get(buildingsOutsidersUndead: Boolean, cursedItems: Boolean): List<CardDefinition> {
-        val cardV2Names = getCardsV2().map { it.name() }.toList()
-        val baseCards = if (buildingsOutsidersUndead)
-            getBaseCards().minus(getBaseCards().filter { cardV2Names.contains(it.name()) }.toSet())
-                .plus(getCardsV2()) else getBaseCards()
+    fun getDeluxeEditionChangedCards(): List<CardDefinition> = listOf(
+        wildfireDeluxeEdition,
+        phoenixDeluxeEdition
+    )
 
-        val newBaseCardsFromExpansion: List<CardDefinition> =
-            if (buildingsOutsidersUndead) getCursedHoardNewCards() else emptyList()
+    fun get(buildingsOutsidersUndead: Boolean, cursedItems: Boolean, deluxeEdition: Boolean): List<CardDefinition> {
+        val phoenixJester = true // Possibility to add a setting in the future
 
-        val cursedItemsDefinitions: List<CardDefinition> =
-            if (cursedItems) getCursedItems() else emptyList()
+        val cards = getBaseCards().toMutableList()
 
-        return newBaseCardsFromExpansion.plus(baseCards).plus(cursedItemsDefinitions).plus(getPromo())
+        if (phoenixJester) cards += getPromo()
+
+        if (buildingsOutsidersUndead) {
+            val cardV2Names = getCardsV2().map { it.name() }
+            cards.removeAll { it.name() in cardV2Names }
+            cards += getCardsV2()
+            cards += getCursedHoardNewCards()
+        }
+
+        if (cursedItems) cards += getCursedItems()
+
+        if (deluxeEdition) {
+            cards.removeAll { it.name() == wildfireDeluxeEdition.name() }
+            cards += wildfireDeluxeEdition
+
+//            return listOf(wildfireDeluxeEdition, candle)
+            if (phoenixJester) { // TODO
+                cards.removeAll { it.name() == phoenixDeluxeEdition.name() }
+                cards += phoenixDeluxeEdition
+            }
+        }
+
+        return cards
     }
-
 }
 
 /**

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/CardDefinitions.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/CardDefinitions.kt
@@ -177,8 +177,7 @@ object CardDefinitions {
             cards.removeAll { it.name() == wildfireDeluxeEdition.name() }
             cards += wildfireDeluxeEdition
 
-//            return listOf(wildfireDeluxeEdition, candle)
-            if (phoenixJester) { // TODO
+            if (phoenixJester) {
                 cards.removeAll { it.name() == phoenixDeluxeEdition.name() }
                 cards += phoenixDeluxeEdition
             }

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/CardSelection.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/CardSelection.kt
@@ -120,7 +120,8 @@ class ShapeShifterSelection : CardSelection(shapeshifter) {
     override fun candidates(game: Game): List<CardDefinition> =
         CardDefinitions.get(
             buildingsOutsidersUndead = false,
-            cursedItems = false
+            cursedItems = false,
+            deluxeEdition = game.deluxeEdition
         ).filter { definition ->
             definition.isOneOf(
                 Suit.ARTIFACT,
@@ -150,7 +151,8 @@ class ShapeShifterV2Selection : CardSelection(shapeshifterV2) {
     override fun candidates(game: Game): List<CardDefinition> =
         CardDefinitions.get(
             buildingsOutsidersUndead = true,
-            cursedItems = false
+            cursedItems = false,
+            deluxeEdition = game.deluxeEdition
         ).filter { definition ->
             definition.isOneOf(
                 Suit.ARTIFACT,
@@ -181,7 +183,8 @@ class MirageSelection : CardSelection(mirage) {
     override fun candidates(game: Game): List<CardDefinition> =
         CardDefinitions.get(
             buildingsOutsidersUndead = false,
-            cursedItems = false
+            cursedItems = false,
+            deluxeEdition = game.deluxeEdition
         ).filter { definition ->
             definition.isOneOf(
                 Suit.ARMY,
@@ -211,7 +214,8 @@ class MirageV2Selection : CardSelection(mirageV2) {
     override fun candidates(game: Game): List<CardDefinition> =
         CardDefinitions.get(
             buildingsOutsidersUndead = true,
-            cursedItems = false
+            cursedItems = false,
+            deluxeEdition = game.deluxeEdition
         ).filter { definition ->
             definition.isOneOf(
                 Suit.ARMY,
@@ -253,8 +257,5 @@ class BookOfChangesSelection : CardAndSuitSelection(bookOfChanges) {
 
     override fun candidates(game: Game): List<CardDefinition> =
         game.handCards().map { card -> card.definition }
-            .filter { definition -> definition != bookOfChanges }
-
+            .filter { definition -> definition != bookOfChanges && definition != phoenixDeluxeEdition }
 }
-
-

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/CommonCardRules.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/CommonCardRules.kt
@@ -17,8 +17,8 @@ open class Rule<T>(val tags: List<Tag>, val priority: Int = 100, val logic: (Gam
  * Rule about effect (like UNBLANKABLE)
  *
  */
-class RuleAboutEffect(tags: List<Tag>, priority: Int = 100, logic: (Game) -> Effect) :
-    Rule<Effect>(tags, priority, logic)
+class RuleAboutEffect(tags: List<Tag>, priority: Int = 100, logic: (Game) -> Effect?) :
+    Rule<Effect?>(tags, priority, logic)
 
 val unblankable by lazy {
     RuleAboutEffect(listOf(Effect.BONUS, Effect.UNBLANKABLE)) { Effect.UNBLANKABLE }
@@ -34,8 +34,8 @@ class RuleAboutScore(tags: List<Tag>, priority: Int = 100, logic: (Game) -> Int)
 /**
  * Rule about rule (like deactivate other rules)
  */
-class RuleAboutRule(tags: List<Tag>, priority: Int = 100, logic: (Game) -> List<Rule<out Any>>) :
-    Rule<List<Rule<out Any>>>(tags, priority, logic)
+class RuleAboutRule(tags: List<Tag>, priority: Int = 100, logic: (Game) -> List<Rule<*>>) :
+    Rule<List<Rule<*>>>(tags, priority, logic)
 
 /**
  * Rule about cards (like blank some cards)
@@ -187,6 +187,19 @@ object AllRules {
                 it.filterNotBlankedHandCards { card ->
                     !(card.isOneOf(Suit.FLAME) || card.isOneOf(Suit.WEATHER) || card.isOneOf(Suit.WIZARD) ||
                             card.isOneOf(Suit.WEAPON) || card.isOneOf(Suit.ARTIFACT) ||
+                            card.hasSameNameThan(greatFlood) ||
+                            card.hasSameNameThan(island) ||
+                            card.hasSameNameThan(mountain) ||
+                            card.hasSameNameThan(unicorn) ||
+                            card.hasSameNameThan(dragon))
+                }
+            }
+        ),
+        wildfireDeluxeEdition to listOf(
+            RuleAboutCard(listOf(Effect.PENALTY, Effect.BLANK)) {
+                it.filterNotBlankedHandCards { card ->
+                    !(card.isOneOf(Suit.FLAME) || card.isOneOf(Suit.WEATHER) || card.isOneOf(Suit.WIZARD) ||
+                            card.isOneOf(Suit.WEAPON) || card.isOneOf(Suit.ARTIFACT) || card.isOneOf(Suit.OUTSIDER) ||
                             card.hasSameNameThan(greatFlood) ||
                             card.hasSameNameThan(island) ||
                             card.hasSameNameThan(mountain) ||
@@ -391,7 +404,7 @@ object AllRules {
             },
             RuleAboutCard(listOf(Effect.PENALTY, Effect.BLANK))
             {
-                if (it.atLeastOneHandCardOf(Suit.WEATHER)) it.filterNotBlankedHandCards { card ->
+                if (it.atLeastOneHandCardOfExcept(Suit.WEATHER, phoenixDeluxeEdition)) it.filterNotBlankedHandCards { card ->
                     card.hasSameNameThan(
                         warDirigible
                     )
@@ -526,7 +539,7 @@ object AllRules {
                     listOf(Suit.LAND,
                     Suit.FLOOD,
                     Suit.FLAME,
-                    Suit.WEATHER), phoenix
+                    Suit.WEATHER), phoenix, phoenixDeluxeEdition
                 ) + DiscardArea.instance.game().containsHandCards(unicorn).toInt()) * 5
             }
         ),
@@ -714,8 +727,16 @@ object AllRules {
                     )
                 } else emptyList()
             }
+        ),
+        phoenixDeluxeEdition to listOf(
+            RuleAboutCard(listOf(Effect.PENALTY, Effect.BLANK)) { // TODO check if works
+                if (it.atLeastOneHandCardOf(Suit.FLOOD)) it.filterNotBlankedHandCards { card ->
+                    card.hasSameNameThan(phoenixDeluxeEdition)
+                } else emptyList()
+            },
+            RuleAboutEffect(listOf(Effect.BONUS, Effect.UNBLANKABLE)) {
+                if (!it.atLeastOneHandCardOf(Suit.FLOOD)) Effect.UNBLANKABLE else null
+            }
         )
-
     )
-
 }

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/CommonCardRules.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/CommonCardRules.kt
@@ -729,7 +729,7 @@ object AllRules {
             }
         ),
         phoenixDeluxeEdition to listOf(
-            RuleAboutCard(listOf(Effect.PENALTY, Effect.BLANK)) { // TODO check if works
+            RuleAboutCard(listOf(Effect.PENALTY, Effect.BLANK)) {
                 if (it.atLeastOneHandCardOf(Suit.FLOOD)) it.filterNotBlankedHandCards { card ->
                     card.hasSameNameThan(phoenixDeluxeEdition)
                 } else emptyList()

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/DeluxeEditionSet.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/DeluxeEditionSet.kt
@@ -1,0 +1,30 @@
+package com.klamerek.fantasyrealms.game
+
+import com.klamerek.fantasyrealms.R
+
+// Looking at the other card definitions, I'm guessing that ids have to be unique, so I'm just adding 1000 to the id of the original card
+
+@Suppress("MagicNumber")
+val wildfireDeluxeEdition by lazy {
+    CardDefinition(
+        id = 1016,
+        keyName = R.string.wildfire,
+        value = 40,
+        suit = Suit.FLAME,
+        keyRule = R.string.wildfire_rules_deluxe_edition,
+        cardSet = CardSet.DELUXE_EDITION
+    )
+}
+
+@Suppress("MagicNumber")
+val phoenixDeluxeEdition by lazy {
+    CardDefinition(
+        id = 1667,
+        keyName = R.string.phoenix,
+        value = 14,
+        suit = Suit.BEAST,
+        keyRule = R.string.phoenix_rules_deluxe_edition,
+        cardSet = CardSet.DELUXE_EDITION,
+        additionalSuits = listOf(Suit.FLAME, Suit.WEATHER)
+    )
+}

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/DiscardArea.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/DiscardArea.kt
@@ -10,6 +10,9 @@ class DiscardArea(private val displayId: Int, private val game: Game) : WithGame
     override fun displayScore(): Boolean = false
 
     companion object {
-        val instance: DiscardArea = DiscardArea(R.string.discard_area, Game(true))
+        val instance: DiscardArea = DiscardArea(
+            R.string.discard_area,
+            Game(noScoring = true, deluxeEdition = false) // Without scoring it doesn't matter if deluxe edition is enabled or not
+        )
     }
 }

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/Game.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/Game.kt
@@ -224,8 +224,9 @@ class Game(
     private fun applyBlankingRule(rule: RuleAboutCard?) {
         if (rule?.tags?.contains(Effect.BLANK) == true) {
             rule.logic.invoke(this)
-                .filter { potentialCard -> !potentialCard.rules().contains(unblankable) }
-                .forEach { cardToBlank ->
+                .filter { potentialCard ->
+                    potentialCard.rules().none { it is RuleAboutEffect && it.logic.invoke(this) == Effect.UNBLANKABLE }
+                }.forEach { cardToBlank ->
                     cardToBlank.blanked = true
                 }
         }

--- a/app/src/main/java/com/klamerek/fantasyrealms/game/Game.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/game/Game.kt
@@ -12,7 +12,10 @@ import kotlin.math.min
  * List of cards (player hand) wth scoring calculation
  *
  */
-class Game(val noScoring: Boolean = false) {
+class Game(
+    val deluxeEdition: Boolean,
+    val noScoring: Boolean = false
+) {
 
     private val handCards = ArrayList<Card>()
     private val tableCards = ArrayList<Card>()
@@ -86,14 +89,16 @@ class Game(val noScoring: Boolean = false) {
     fun countHandCardsExcept(suit: Suit, cardDefinition: CardDefinition) =
         handCardsNotBlanked().filter { it.definition != cardDefinition }.count { it.isOneOf(suit) }
 
-    fun countHandCardsExcept(suits: List<Suit>, cardDefinition: CardDefinition) =
-        handCardsNotBlanked().filter { it.definition != cardDefinition }.count { it.isOneOf(*suits.toTypedArray()) }
+    fun countHandCardsExcept(suits: List<Suit>, vararg cardDefinitions: CardDefinition) =
+        handCardsNotBlanked().filter { it.definition !in cardDefinitions }.count { it.isOneOf(*suits.toTypedArray()) }
 
     fun countTableCards(vararg suit: Suit) = tableCards.count { it.isOneOf(*suit) }
 
     fun noHandCardsOf(suit: Suit) = countHandCards(suit) == 0
 
     fun atLeastOneHandCardOf(suit: Suit) = countHandCards(suit) > 0
+
+    fun atLeastOneHandCardOfExcept(suit: Suit, except: CardDefinition) = countHandCardsExcept(suit, except) > 0
 
 
     /**
@@ -169,7 +174,6 @@ class Game(val noScoring: Boolean = false) {
                     .score(this)
             }.toMap())
         }
-
     }
 
     private fun applySpecificCardEffects() {
@@ -227,7 +231,7 @@ class Game(val noScoring: Boolean = false) {
         }
     }
 
-    private fun identifyClearedRules(card: Card): List<Rule<out Any>> =
+    private fun identifyClearedRules(card: Card): List<Rule<*>> =
         card.rules().activated(card).with(Effect.CLEAR)
             .asRuleAboutRule().listRules(this)
 
@@ -245,11 +249,11 @@ class Game(val noScoring: Boolean = false) {
         return this.handCardsNotBlanked().filter(scope)
     }
 
-    fun identifyPenalties(scope: (Card) -> Boolean): List<Rule<out Any>> {
+    fun identifyPenalties(scope: (Card) -> Boolean): List<Rule<*>> {
         return handCardsNotBlanked().filter(scope).rules().with(Effect.PENALTY)
     }
 
-    fun identifyArmyPenalties(scope: (Card) -> Boolean): List<Rule<out Any>> {
+    fun identifyArmyPenalties(scope: (Card) -> Boolean): List<Rule<*>> {
         return handCardsNotBlanked().filter(scope).rules().with(Effect.PENALTY).with(Suit.ARMY)
     }
 

--- a/app/src/main/java/com/klamerek/fantasyrealms/screen/HandSelectionActivity.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/screen/HandSelectionActivity.kt
@@ -125,7 +125,12 @@ class HandSelectionActivity : CustomActivity() {
                 DiscardArea.instance
             }
             Player.all.isEmpty() -> {
-                Player.all.add(Player(Player.generateNextPlayerName(), Game()))
+                Player.all.add(
+                    Player(
+                        Player.generateNextPlayerName(),
+                        Game(deluxeEdition = Preferences.getDeluxeEdition(baseContext))
+                    )
+                )
                 Player.all[0]
             }
             Player.all.size <= index -> {

--- a/app/src/main/java/com/klamerek/fantasyrealms/screen/PlayerSelectionActivity.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/screen/PlayerSelectionActivity.kt
@@ -25,6 +25,7 @@ import com.klamerek.fantasyrealms.game.Game
 import com.klamerek.fantasyrealms.game.Player
 import com.klamerek.fantasyrealms.screen.PlayerSelectionActivity.Companion.playerNameDialog
 import com.klamerek.fantasyrealms.util.Constants
+import com.klamerek.fantasyrealms.util.Preferences
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 
@@ -164,7 +165,7 @@ class PlayerSelectionActivity : CustomActivity() {
     @Subscribe
     fun addPlayer(event: PlayerCreationEvent) {
         runOnUiThread {
-            Player.all.add(Player(event.name, Game()))
+            Player.all.add(Player(event.name, Game(deluxeEdition = Preferences.getDeluxeEdition(baseContext))))
             adapter.notifyDataSetChanged()
         }
     }

--- a/app/src/main/java/com/klamerek/fantasyrealms/screen/SettingsActivity.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/screen/SettingsActivity.kt
@@ -34,7 +34,7 @@ class SettingsActivity : CustomActivity() {
         setContentView(view)
 
         //Needed to make clickable links effective
-        binding.disclaimerLabel.movementMethod = LinkMovementMethod.getInstance();
+        binding.disclaimerLabel.movementMethod = LinkMovementMethod.getInstance()
 
         binding.displayCardNumberCheckBox.isChecked = Preferences.getDisplayCardNumber(baseContext)
         binding.removeAlreadySelectedCheckBox.isChecked = Preferences.getRemoveAlreadySelected(baseContext)
@@ -43,6 +43,7 @@ class SettingsActivity : CustomActivity() {
         binding.withCursedItemsCheckBox.isChecked = Preferences.getCursedItems(baseContext)
         binding.displayChipColorOnSearchCheckBox.isChecked =
             Preferences.getDisplayChipColorOnSearch(baseContext)
+        binding.deluxeEditionCheckBox.isChecked = Preferences.getDeluxeEdition(baseContext)
 
         val initialValue = getCardScopeId()
 
@@ -87,6 +88,10 @@ class SettingsActivity : CustomActivity() {
                 baseContext,
                 binding.removeAlreadySelectedCheckBox.isChecked
             )
+            Preferences.saveDeluxeEditionInPreferences(
+                baseContext,
+                binding.deluxeEditionCheckBox.isChecked
+            )
             removeCardOutOfScope(initialValue)
             finishAfterTransition()
         }
@@ -121,6 +126,7 @@ class SettingsActivity : CustomActivity() {
 
     private fun getCardScopeId() =
         binding.withBuildingsOutsidersUndeadCheckBox.isChecked.toInt().toString() +
-                binding.withCursedItemsCheckBox.isChecked.toInt().toString()
+                binding.withCursedItemsCheckBox.isChecked.toInt().toString() +
+                binding.deluxeEditionCheckBox.isChecked.toInt().toString()
 
 }

--- a/app/src/main/java/com/klamerek/fantasyrealms/util/Extensions.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/util/Extensions.kt
@@ -39,49 +39,49 @@ fun ColorStateList.revertChipColorState(): ColorStateList {
 
 // All collections methods - START
 
-fun Iterable<Card>.rules(): List<Rule<out Any>> {
+fun Iterable<Card>.rules(): List<Rule<*>> {
     return flatMap {
         return@flatMap (it.rules())
     }
 }
 
-fun Iterable<Rule<out Any>>.asRuleAboutRule(): List<RuleAboutRule?> {
+fun Iterable<Rule<*>>.asRuleAboutRule(): List<RuleAboutRule?> {
     return map {
         return@map (it as? RuleAboutRule)
     }
 }
 
-fun Iterable<Rule<out Any>>.asRuleAboutCard(): List<RuleAboutCard?> {
+fun Iterable<Rule<*>>.asRuleAboutCard(): List<RuleAboutCard?> {
     return map {
         return@map (it as? RuleAboutCard)
     }
 }
 
-fun Sequence<Rule<out Any>>.asRuleAboutScore(): Sequence<RuleAboutScore?> {
+fun Sequence<Rule<*>>.asRuleAboutScore(): Sequence<RuleAboutScore?> {
     return map {
         return@map (it as? RuleAboutScore)
     }
 }
 
-fun Iterable<Rule<out Any>>.activated(card: Card): List<Rule<out Any>> {
+fun Iterable<Rule<*>>.activated(card: Card): List<Rule<*>> {
     return filter {
         return@filter (card.isActivated(it))
     }
 }
 
-fun Sequence<Rule<out Any>>.activated(card: Card): Sequence<Rule<out Any>> {
+fun Sequence<Rule<*>>.activated(card: Card): Sequence<Rule<*>> {
     return filter {
         return@filter (card.isActivated(it))
     }
 }
 
-fun <T : Rule<out Any>?> Iterable<T>.with(tag: Tag): List<T> {
+fun <T : Rule<*>?> Iterable<T>.with(tag: Tag): List<T> {
     return filter {
         return@filter (it?.tags?.contains(tag) == true)
     }
 }
 
-fun <T : Rule<out Any>?> Sequence<T>.with(tag: Tag): Sequence<T> {
+fun <T : Rule<*>?> Sequence<T>.with(tag: Tag): Sequence<T> {
     return filter {
         return@filter (it?.tags?.contains(tag) == true)
     }
@@ -96,11 +96,9 @@ fun <T : RuleAboutCard?> Iterable<T>.listCards(game: Game): List<Card> {
     return flatMap { rule -> rule?.logic?.invoke(game).orEmpty() }
 }
 
-fun <T : RuleAboutRule?> Iterable<T>.listRules(game: Game): List<Rule<out Any>> {
+fun <T : RuleAboutRule?> Iterable<T>.listRules(game: Game): List<Rule<*>> {
     return flatMap { rule -> rule?.logic?.invoke(game).orEmpty() }
 }
 
 
 // All collections methods - END
-
-

--- a/app/src/main/java/com/klamerek/fantasyrealms/util/Preferences.kt
+++ b/app/src/main/java/com/klamerek/fantasyrealms/util/Preferences.kt
@@ -76,6 +76,21 @@ object Preferences {
         }
     }
 
+    fun getDeluxeEdition(context: Context): Boolean {
+        return sharedPreferences(context).getBoolean(
+            context.getString(R.string.deluxe_edition),
+            false
+        )
+    }
+
+    fun saveDeluxeEditionInPreferences(context: Context, activate: Boolean) {
+        val sharedPref = sharedPreferences(context)
+        with(sharedPref.edit()) {
+            putBoolean(context.getString(R.string.deluxe_edition), activate)
+            apply()
+        }
+    }
+
     fun saveDisplayChipColorOnSearchInPreferences(context: Context, activate: Boolean) {
         val sharedPref = sharedPreferences(context)
         with(sharedPref.edit()) {

--- a/app/src/main/res/layout/activity_cards_selection.xml
+++ b/app/src/main/res/layout/activity_cards_selection.xml
@@ -278,6 +278,19 @@
                 app:chipStrokeWidth="2dp" />
 
             <com.google.android.material.chip.Chip
+                android:id="@+id/chipwildfireDeluxeEdition"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checkable="true"
+                android:tag="1016"
+                android:transitionName="transition_chip_1016"
+                android:text="@string/wildfire"
+                android:textColor="@color/chip_revert_color_activated"
+                app:chipBackgroundColor="@color/chip_background_flame"
+                app:chipStrokeColor="@color/chip_stroke_color_flame"
+                app:chipStrokeWidth="2dp" />
+
+            <com.google.android.material.chip.Chip
                 android:id="@+id/chipcandle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -635,6 +648,19 @@
                 android:checkable="true"
                 android:tag="667"
                 android:transitionName="transition_chip_667"
+                android:text="@string/phoenix"
+                android:textColor="@color/chip_revert_color_activated"
+                app:chipBackgroundColor="@color/chip_background_beast"
+                app:chipStrokeColor="@color/chip_stroke_color_beast"
+                app:chipStrokeWidth="2dp" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/phoenixDeluxeEdition"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checkable="true"
+                android:tag="1667"
+                android:transitionName="transition_chip_1667"
                 android:text="@string/phoenix"
                 android:textColor="@color/chip_revert_color_activated"
                 app:chipBackgroundColor="@color/chip_background_beast"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -8,10 +8,11 @@
     android:orientation="vertical"
     tools:context=".screen.SettingsActivity">
 
+    <!-- The layout preview doesn't seem to display the line breaks correctly but it works on my device -->
     <TextView
         android:id="@+id/disclaimerLabel"
         android:layout_width="wrap_content"
-        android:layout_height="150dp"
+        android:layout_height="wrap_content"
         android:clickable="true"
         android:gravity="center"
         android:text="@string/disclaimer"
@@ -114,17 +115,21 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"/>
+
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/displayCardNumberLayout"
+                android:id="@+id/deluxeEditionLayout"
                 android:layout_width="match_parent"
                 android:layout_height="60dp">
 
                 <TextView
-                    android:id="@+id/displayCardNumberLabel"
+                    android:id="@+id/deluxeEditionLabel"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="10dp"
-                    android:text="@string/display_card_number_label"
+                    android:text="@string/deluxe_edition_label"
                     android:textColor="?android:attr/textColorPrimary"
                     android:textSize="14sp"
                     android:textStyle="bold"
@@ -133,91 +138,16 @@
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <Space
-                    android:id="@+id/spaceDisplayCardNumber"
+                    android:id="@+id/spaceDeluxeEditionUndead"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/displayCardNumberCheckBox"
-                    app:layout_constraintStart_toEndOf="@id/displayCardNumberLabel"
+                    app:layout_constraintEnd_toStartOf="@id/deluxeEditionCheckBox"
+                    app:layout_constraintStart_toEndOf="@id/deluxeEditionLabel"
                     app:layout_constraintTop_toTopOf="parent" />
 
                 <CheckBox
-                    android:id="@+id/displayCardNumberCheckBox"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="25dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/colorChipModeLayout"
-                android:layout_width="match_parent"
-                android:layout_height="60dp">
-
-                <TextView
-                    android:id="@+id/displayChipColorOnSearchLabel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="10dp"
-                    android:text="@string/display_chip_color_on_search_label"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="14sp"
-                    android:textStyle="bold"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <Space
-                    android:id="@+id/spaceColorChipMode"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/displayChipColorOnSearchCheckBox"
-                    app:layout_constraintStart_toEndOf="@id/displayChipColorOnSearchLabel"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <CheckBox
-                    android:id="@+id/displayChipColorOnSearchCheckBox"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="25dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/removeAlreadySelectedLayout"
-                android:layout_width="match_parent"
-                android:layout_height="60dp">
-
-                <TextView
-                    android:id="@+id/removeAlreadySelectedLabel"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="10dp"
-                    android:text="@string/remove_already_selected_label"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="14sp"
-                    android:textStyle="bold"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <Space
-                    android:id="@+id/spaceRemoveAlreadySelected"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/removeAlreadySelectedCheckBox"
-                    app:layout_constraintStart_toEndOf="@id/removeAlreadySelectedLabel"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <CheckBox
-                    android:id="@+id/removeAlreadySelectedCheckBox"
+                    android:id="@+id/deluxeEditionCheckBox"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="25dp"
@@ -300,6 +230,121 @@
                     app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <com.google.android.material.divider.MaterialDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/removeAlreadySelectedLayout"
+                android:layout_width="match_parent"
+                android:layout_height="60dp">
+
+                <TextView
+                    android:id="@+id/removeAlreadySelectedLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:text="@string/remove_already_selected_label"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <Space
+                    android:id="@+id/spaceRemoveAlreadySelected"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/removeAlreadySelectedCheckBox"
+                    app:layout_constraintStart_toEndOf="@id/removeAlreadySelectedLabel"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <CheckBox
+                    android:id="@+id/removeAlreadySelectedCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="25dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/displayCardNumberLayout"
+                android:layout_width="match_parent"
+                android:layout_height="60dp">
+
+                <TextView
+                    android:id="@+id/displayCardNumberLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:text="@string/display_card_number_label"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <Space
+                    android:id="@+id/spaceDisplayCardNumber"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/displayCardNumberCheckBox"
+                    app:layout_constraintStart_toEndOf="@id/displayCardNumberLabel"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <CheckBox
+                    android:id="@+id/displayCardNumberCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="25dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/colorChipModeLayout"
+                android:layout_width="match_parent"
+                android:layout_height="60dp">
+
+                <TextView
+                    android:id="@+id/displayChipColorOnSearchLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="10dp"
+                    android:text="@string/display_chip_color_on_search_label"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textSize="14sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <Space
+                    android:id="@+id/spaceColorChipMode"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/displayChipColorOnSearchCheckBox"
+                    app:layout_constraintStart_toEndOf="@id/displayChipColorOnSearchLabel"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <CheckBox
+                    android:id="@+id/displayChipColorOnSearchCheckBox"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="25dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </LinearLayout>
     </ScrollView>
 

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -8,4 +8,5 @@
     <string name="cursed_items" translatable="false">cursed_items</string>
     <string name="buildings_outsiders_undead" translatable="false">buildings_outsiders_undead</string>
     <string name="display_chip_color_on_search" translatable="false">display_chip_color_on_search</string>
+    <string name="deluxe_edition" translatable="false">deluxe_edition</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,9 +18,7 @@
     <string name="clear_button">Clear</string>
     <string name="scan_help_label">Tip: only card titles are mandatory</string>
     <string name="base">BASE</string>
-    <string name="disclaimer" translatable="false">V 0.34 \n
-        (Scan may not work with non latin alphabet)\nNot compatible with deluxe edition\nFound a bug ? \nWant to contribute ? \nContact me (<a href="https://github.com/benjamin-klamerek/fantasy-realm-scoring">github</a> or <a href="mailto:benjamin.klamerek@gmail.com">mail</a>)
-        \n\n\n Icons made by Freepik and Smashicons from <a href="www.flaticon.com">www.flaticon.com</a></string>
+    <string name="disclaimer" translatable="false">v0.34\n(Scan may not work with non latin alphabet)\nFound a bug? Want to contribute? Contact me: <a href="https://github.com/benjamin-klamerek/fantasy-realm-scoring">github</a> or <a href="mailto:benjamin.klamerek@gmail.com">email</a>\n\nIcons made by Freepik and Smashicons from <a href="www.flaticon.com">www.flaticon.com</a></string>
     <string name="done">Done</string>
     <string name="scan_mode_label" translatable="false">Scan mode:</string>
     <string name="language_label">Language:</string>
@@ -36,6 +34,7 @@
     <string name="display_card_number_label">Display card number:</string>
     <string name="remove_already_selected_label">Remove cards already selected:</string>
     <string name="display_chip_color_on_search_label">Display chip color on search:</string>
+    <string name="deluxe_edition_label">Deluxe Edition:</string>
     <string name="buildings_outsiders_undead_label">Buildings, outsiders and undead:</string>
     <string name="cursed_items_label">Cursed items:</string>
     <string name="discard_area">Discard area</string>
@@ -177,6 +176,7 @@
     <string name="forge_rules">Bonus: +9 for each Weapon and Artifact</string>
     <string name="lightning_rules">Bonus: +30 with Rainstorm</string>
     <string name="wildfire_rules">Blanks all cards except Flames, Weather, Wizards, Weapons, Artifacts, Great Flood, Island, Mountain, Unicorn, Dragon</string>
+    <string name="wildfire_rules_deluxe_edition">Blanks all cards except Artifacts, Flames, Outsiders, Weapons, Weather, Wizards, Great Flood, Island, Mountain, Unicorn, Dragon</string>
     <string name="fountain_of_life_rules">Bonus: Add the base strength of any Weapon, Flood, Flame, Land, or Weather in your hand</string>
     <string name="water_elemental_rules">Bonus: +15 for each other Flood</string>
     <string name="island_rules">Clears the Penalty on any one Flood or Flame</string>
@@ -259,4 +259,5 @@
     <string name="wishing_ring_rules">ANY TIME: Look through the deck and place any card you wish on top. \n(You may do this immediately before you draw.) \nReshuffle the deck at the end of your turn.</string>
     <string name="jester_rules">BONUS: +3 for each other card with an odd base strength value OR +50 if entire hand has odd base strength values.</string>
     <string name="phoenix_rules">BONUS: also counts as a Flame and Weather card. PENALTY: BLANKED with any Flood card. If this card is BLANKED for any reason, its base strength is reduced to 0 but it retains its suits.</string>
+    <string name="phoenix_rules_deluxe_edition">BONUS: also counts as a Flame and Weather card. PENALTY: BLANKED with any Flood. Phoenix is immune to the Book of Changes and may not Blank or be Blanked by any other card.</string>
 </resources>


### PR DESCRIPTION
* Added a setting to enable Deluxe Edition
* The wildfire no longer blanks outsiders if the setting is enabled
* The phoenix logic uses the logic of the deluxe edition if the setting is enabled ("Phoenix is immune to the Book of Changes and may not Blank or be Blanked by any other card" instead of "If this card is BLANKED for any reason, its base strength is reduced to 0 but it retains its suits")
* Reordered the settings page to better fit in the new setting and added some horizontal dividers to improve organization
* Updated the disclaimer on the settings page

I tested the changes on my phone and everything seems to work, however I was unable to run the unit tests. When clicking on the play icon in Android Studio I only got 0/0 tests passed.

Also, the changes aren't translated yet. I could be able to add German translations in a future pull request.